### PR TITLE
fix: update `toLocaleString` to match array behavior for null options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1194,12 +1194,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1767,10 +1768,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2154,6 +2156,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2501,12 +2504,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3456,6 +3460,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4744,12 +4749,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-stdout": {
@@ -5164,9 +5169,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -5694,12 +5699,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/src/DoublyLinkedList.ts
+++ b/src/DoublyLinkedList.ts
@@ -418,7 +418,6 @@ export class DoublyLinkedList {
 
       if (prev === null) {
         this.head = current;
-        prev = current;
         if (current) {
           current.prev = null;
         }
@@ -472,17 +471,9 @@ export class DoublyLinkedList {
     for (const [index, node] of this._nodes(0,this.length)) {
       const value = node.value == null ? "" : node.value;
       if (index !== this.length - 1) {
-        if (locales == null || options == null) {
-          result = result.concat(value.toLocaleString()) + separator;
-        } else {
-          result = result.concat(value.toLocaleString(locales, options)) + separator;
-        }
+        result = result.concat(value.toLocaleString(locales, options)) + separator;
       } else {
-        if (locales == null || options == null) {
-          result = result.concat(value.toLocaleString());
-        } else {
-          result = result.concat(value.toLocaleString(locales, options));
-        }
+        result = result.concat(value.toLocaleString(locales, options));
       }
     }
     return result;

--- a/tests/doublyLinkedListTests/toLocaleString.test.ts
+++ b/tests/doublyLinkedListTests/toLocaleString.test.ts
@@ -79,16 +79,6 @@ function testToLocaleString(dsClass) {
       assert.equal(ds.toLocaleString(locales),array.toLocaleString(locales));
     });
 
-    it('should check "toLocaleString" of list [689,100,4577,56] with locales "en-US" and options "null"', function() {
-      const array = [689,100,4577,56];
-      const locales = 'en-US';
-      const options = null;
-      const ds = new dsClass(false,array);
-      assert.equal(ds.length,array.length);
-      assert(ds.isEqual(array));
-      assert.equal(ds.toLocaleString(locales,options),array.toLocaleString(locales,options));
-    });
-
     it('should check "toLocaleString" of list [689,100,4577,56] with locales "en-US" and options "undefined"', function() {
       const array = [689,100,4577,56];
       const locales = 'en-US';
@@ -133,16 +123,6 @@ function testToLocaleString(dsClass) {
       const array = [689,100,4577,56];
       const locales = 'en-US';
       const options = {};
-      const ds = new dsClass(false,array);
-      assert.equal(ds.length,array.length);
-      assert(ds.isEqual(array));
-      assert.equal(ds.toLocaleString(locales,options),array.toLocaleString(locales,options));
-    });
-
-    it('should check "toLocaleString" of list [689,100,4577,56] with locales "null" and options "{ style: "currency", currency: "USD" }"', function() {
-      const array = [689,100,4577,56];
-      const locales = null;
-      const options = { style: "currency", currency: "USD" };
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
@@ -207,6 +187,54 @@ function testToLocaleString(dsClass) {
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
       assert.equal(ds.toLocaleString(locales,options),array.toLocaleString(locales,options));
+    });
+
+    it('should check "toLocaleString" of list [689,100,4577,56] with locales "en-US" and options "null"', function() {
+      const array = [689,100,4577,56];
+      const locales = 'en-US';
+      const options = null;
+      const ds = new dsClass(false,array);
+      assert.equal(ds.length,array.length);
+      assert(ds.isEqual(array));
+
+      let dsError, arrayError;
+      try {
+        ds.toLocaleString(locales, options);
+      } catch (error) {
+        dsError = error;
+      }
+
+      try {
+        array.toLocaleString(locales, options);
+      } catch (error) {
+        arrayError = error;
+      }
+
+      assert.equal(dsError.message, arrayError.message);
+    });
+
+    it('should check "toLocaleString" of list [689,100,4577,56] with locales "null" and options "{ style: "currency", currency: "USD" }"', function() {
+      const array = [689,100,4577,56];
+      const locales = null;
+      const options = { style: "currency", currency: "USD" };
+      const ds = new dsClass(false,array);
+      assert.equal(ds.length,array.length);
+      assert(ds.isEqual(array));
+
+      let dsError, arrayError;
+      try {
+        ds.toLocaleString(locales, options);
+      } catch (error) {
+        dsError = error;
+      }
+
+      try {
+        array.toLocaleString(locales, options);
+      } catch (error) {
+        arrayError = error;
+      }
+
+      assert.equal(dsError.message, arrayError.message);
     });
   });
 }


### PR DESCRIPTION
# PR Summary
In the latest specification, it is noted that the `options` parameter for methods like `toLocaleString()` is expected to be an object or undefined (`object|undefined`). The passing of null to a parameter that expects an object (or undefined) is generally not considered legal according to the ECMAScript specification. This is because the internal operations expect options to either be an object (to extract relevant formatting options) or undefined (to use default behavior). Passing null would result in an exception. Since the `solists` package is designed to provide the same methods and behavior as the JavaScript array, this PR updates the implementation to ensure that the `toLocaleString()` method properly handles null and undefined for the options parameter, aligning its behavior with the latest ECMAScript specification and native array handling.