### PR TITLE
fix: add function arg type to reduce error message

### DIFF
--- a/src/DoublyLinkedList.ts
+++ b/src/DoublyLinkedList.ts
@@ -300,8 +300,11 @@ export class DoublyLinkedList {
   }
 
   public reduce(callbackFn: any, initialValue: any): any {
-    if (!(this._isCallable(callbackFn))) {
-      throw TypeError(this._tryToString(callbackFn) + ' is not a function');
+    if (!this._isCallable(callbackFn)) {
+      const type = typeof callbackFn;
+      const value = this._tryToString(callbackFn);
+      const typePrefix = type !== 'undefined' ? type + ' ' : '';
+      throw TypeError(`${typePrefix}${value} is not a function`);
     }
     if (this.length === 0 && arguments.length < 2) {
       throw TypeError('Reduce of empty list with no initial value');
@@ -316,8 +319,11 @@ export class DoublyLinkedList {
   }
 
   public reduceRight(callbackFn: any, initialValue: any): any {
-    if (!(this._isCallable(callbackFn))) {
-      throw TypeError(this._tryToString(callbackFn) + ' is not a function');
+    if (!this._isCallable(callbackFn)) {
+      const type = typeof callbackFn;
+      const value = this._tryToString(callbackFn);
+      const typePrefix = type !== 'undefined' ? type + ' ' : '';
+      throw TypeError(`${typePrefix}${value} is not a function`);
     }
     if (this.length === 0 && arguments.length < 2) {
       throw TypeError('Reduce of empty list with no initial value');

--- a/tests/doublyLinkedListTests/reduce.test.ts
+++ b/tests/doublyLinkedListTests/reduce.test.ts
@@ -81,8 +81,8 @@ function testReduce(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduce(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduce(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduce" of "undefined" function on list [1,2,3,4,5]', function() {
@@ -91,8 +91,8 @@ function testReduce(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduce(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduce(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduce(),TypeError('undefined is not a function'));
+      assert.throws(() => ds.reduce(),TypeError('undefined is not a function'));
     });
 
     it('should check "reduce" of "NaN" function on list [1,2,3,4,5]', function() {
@@ -101,8 +101,8 @@ function testReduce(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduce(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduce(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduce" of "Infinity" function on list [1,2,3,4,5]', function() {
@@ -111,8 +111,8 @@ function testReduce(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduce(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduce(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduce" of "-0" function on list [1,2,3,4,5]', function() {
@@ -121,8 +121,8 @@ function testReduce(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduce(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduce(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduce(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduce" of max value of list [-10,20,100,0,30] from initial value "200"', function() {

--- a/tests/doublyLinkedListTests/reduceRight.test.ts
+++ b/tests/doublyLinkedListTests/reduceRight.test.ts
@@ -72,8 +72,8 @@ function testReduceRight(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduceRight(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduceRight(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduceRight" of "undefined" function on list [1,2,3,4,5]', function() {
@@ -82,8 +82,8 @@ function testReduceRight(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduceRight(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduceRight(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduceRight(func),TypeError('undefined is not a function'));
+      assert.throws(() => ds.reduceRight(func),TypeError('undefined is not a function'));
     });
 
     it('should check "reduceRight" of "NaN" function on list [1,2,3,4,5]', function() {
@@ -92,8 +92,8 @@ function testReduceRight(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduceRight(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduceRight(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduceRight" of "Infinity" function on list [1,2,3,4,5]', function() {
@@ -102,8 +102,8 @@ function testReduceRight(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduceRight(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduceRight(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduceRight" of "-0" function on list [1,2,3,4,5]', function() {
@@ -112,8 +112,8 @@ function testReduceRight(dsClass) {
       const ds = new dsClass(false,array);
       assert.equal(ds.length,array.length);
       assert(ds.isEqual(array));
-      assert.throws(() => array.reduceRight(func),TypeError(func + ' is not a function'));
-      assert.throws(() => ds.reduceRight(func),TypeError(func + ' is not a function'));
+      assert.throws(() => array.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
+      assert.throws(() => ds.reduceRight(func),TypeError(`${typeof func} ${String(func)} is not a function`));
     });
 
     it('should check "reduceRight" of max value of list [-10,20,100,0,30] from initial value "200"', function() {


### PR DESCRIPTION
## PR Summary
This PR adds a function argument type to error messages in `reduce` and `reduceRight`, matching latest JS array behavior. Example:
```typescript
const solist = new FrequencyCountSoList(false, [1, 2, 3]);
const arr = [1, 2, 3];

arr.reduce(0);
solist.reduce(0); 
```
In previous versions, the error was `0 is not a function`. Recent versions now print `number 0 is not a function`.